### PR TITLE
Fix figure references in captions

### DIFF
--- a/draft-bormann-asdf-instance-information.md
+++ b/draft-bormann-asdf-instance-information.md
@@ -298,7 +298,7 @@ the instance's proofshot as the location is known. <!-- Not really sure about th
     }
 }
 ~~~
-{: #code-off-device-instance title="SDF instance proposal for draft-lee-asdf-digital-twin-07, Figure 1"}
+{: #code-off-device-instance title="SDF instance proposal for draft-lee-asdf-digital-twin-07, Figure 2"}
 
 ~~~ json
 {
@@ -385,7 +385,7 @@ the instance's proofshot as the location is known. <!-- Not really sure about th
     }
 }
 ~~~
-{: #code-off-device-model title="Revised SDF model proposal for draft-lee-asdf-digital-twin-07, Figure 1"}
+{: #code-off-device-model title="Revised SDF model proposal for draft-lee-asdf-digital-twin-07, Figure 2"}
 
 ### Construction
 


### PR DESCRIPTION
Since the ordering of the figures has changed in the latest version of draft-lee-asdf-digital-twin, this PR updates the captions within the document to reflect that (sorry for not noticing this earlier).