### PR TITLE
Add `...` to end the YAML header

### DIFF
--- a/draft-bormann-asdf-instance-information.md
+++ b/draft-bormann-asdf-instance-information.md
@@ -68,6 +68,7 @@ informative:
     date: false
   STP: I-D.bormann-t2trg-stp
   RFC9039: device-id
+...
 
 --- abstract
 


### PR DESCRIPTION
In my local editor, I get a strange ... syntax highlighting of the Markdown document, since my editor is not noticing that the YAML header has actually ended:

<img width="724" height="303" alt="grafik" src="https://github.com/user-attachments/assets/58dac3c3-5bec-48d2-99a0-d2e579714969" />

This PR proposes to explicitly end the YAML header with an additional `...`, resolving the editor confusion (apparently without breaking the document).
