### PR TITLE
Add a `version` quality to `sdfInstanceOf`

### DIFF
--- a/draft-ietf-asdf-instance-information.md
+++ b/draft-ietf-asdf-instance-information.md
@@ -372,11 +372,13 @@ In constrast to models, including a `namespace` quality is mandatory as at least
 
 Distinct from SDF models are two instance-specific blocks, the first of which is identified via the `sdfInstanceOf` keyword.
 Via the `model` keyword, this quality defines the entry point the `sdfInstance` quality from the next section is referring to.
+The `version` quality optionally allows for specifying a version or version range of the model.
 Furthermore, via the `patchMethod` field, a patch algorithm different from JSON Merge Patch can be specified.
 
 | Quality          | Type   | Description                                                                                                                                                    |
 |------------------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | model            | string | Defines the entry point for `sdfInstance` by pointing to an `sdfObject` or an `sdfThing`. Has to be based on a namespace identifier from the `namespaces` map. |
+| version          | string | The version or a compatible version range of the model this message is referring to.                                                                           |
 | patchMethod      | string | Allows for overriding the default patch method (JSON Merge Patch) by providing a registered value.                                                             |
 | $comment         | string | Source code comments only, no semantics                                                                                                                        |
 {: #iobsec title="Instance-of Block"}


### PR DESCRIPTION
In order to connect instance-related messages and instantiation to the other dimension of model evolution – derivation – this PR adds an optional `version` quality to the `sdfInstanceOf` map. 

Adding this quality should also make it possible to refer a version _range_, e.g., indicating that backwards-compatible/patch releases should “automatically” be taken into account.